### PR TITLE
Mark plugin as thread safe

### DIFF
--- a/src/main/java/org/codehaus/mojo/javacc/JavaCCMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JavaCCMojo.java
@@ -31,6 +31,7 @@ import org.apache.maven.plugin.MojoFailureException;
  *
  * @goal javacc
  * @phase generate-sources
+ * @threadSafe
  * @since 2.0
  * @author jruiz@exist.com
  * @author jesse <jesse.mcconnell@gmail.com>


### PR DESCRIPTION
@phax 

Please consider using maven-plugin-annotations and its `@Mojo` annotation in the longer term. But this gets rid of the now unnecessary warning:

```
[WARNING] *****************************************************************
[WARNING] * Your build is requesting parallel execution, but project      *
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] * question, not against maven-core                              *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe in document:
[WARNING] com.helger.maven:ph-javacc-maven-plugin:4.1.2-SNAPSHOT
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************
```